### PR TITLE
Get method for origin property

### DIFF
--- a/addon/-base-url.js
+++ b/addon/-base-url.js
@@ -36,6 +36,10 @@ class BaseURL {
     this._setPart('host', value);
   }
 
+  get origin() {
+    return this._urlObject.origin;
+  }
+
   get hostname() {
     return this._urlObject.hostname;
   }


### PR DESCRIPTION
This PR introduces `get` method for `origin` read-only property https://url.spec.whatwg.org/#dom-url-origin.